### PR TITLE
Allow input path specification and show progress bar

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     gpxpy
     matplotlib
     pandas
+    rich
     seaborn
 python_requires = >=3.7
 package_dir = =src

--- a/src/strava_py/cli.py
+++ b/src/strava_py/cli.py
@@ -1,15 +1,23 @@
 import argparse
-
+import os.path
 
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument("path", help="Input path to folder with GPX and / or FIT files")
+    parser.add_argument(
+        "path", help="Input path specification to folder with GPX and / or FIT files"
+    )
     parser.add_argument(
         "-o", "--output_file", default="plot.png", help="Output PNG file"
     )
     args = parser.parse_args()
+
+    if os.path.isdir(args.path):
+        args.path = os.path.join(args.path, "*")
+
+    # Expand "~" or "~user"
+    args.path = os.path.expanduser(args.path)
 
     # Normally imports go at the top, but scientific libraries can be slow to import
     # so let's validate arguments first

--- a/src/strava_py/process_data.py
+++ b/src/strava_py/process_data.py
@@ -3,6 +3,7 @@ import glob
 import fit2gpx
 import gpxpy
 import pandas as pd
+from rich.progress import track
 
 
 # Function for processing (unzipped) GPX and FIT files in a directory (path)
@@ -56,7 +57,7 @@ def process_data(path):
     # Process all files (GPX or FIT)
     processed = []
 
-    for fpath in glob.iglob(path):
+    for fpath in track(glob.glob(path), description="Processing:"):
         if fpath.endswith('.gpx'):
             processed.append(process_gpx(fpath))
         elif fpath.endswith('.fit'):

--- a/src/strava_py/process_data.py
+++ b/src/strava_py/process_data.py
@@ -1,6 +1,7 @@
+import glob
+
 import fit2gpx
 import gpxpy
-import os.path
 import pandas as pd
 
 
@@ -54,15 +55,14 @@ def process_data(path):
     
     # Process all files (GPX or FIT)
     processed = []
-    
-    for file in os.listdir(path):
-        fpath = path + '/' + file
+
+    for fpath in glob.iglob(path):
         if fpath.endswith('.gpx'):
             processed.append(process_gpx(fpath))
         elif fpath.endswith('.fit'):
             processed.append(process_fit(fpath))
-        print('Processing: ' + file)
-    
+        print('Processing: ' + fpath)
+
     df = pd.concat(processed)
     
     df['time'] = pd.to_datetime(df['time'], utc = True)


### PR DESCRIPTION
Two things:

* Instead of inputting a path such as `~/github/strava-tools/activities/`, allow using a path specification using [`glob`](https://docs.python.org/3/library/glob.html#glob.glob) that can match wildcards such as `~/github/strava-tools/activities/202107*`
  * If your activities have been renamed to include dates ([for example](https://github.com/hugovk/strava-tools#rename-and-unzip-files)), this makes it easy to only generate visualisations for a given month or year
* Add a progress bar using [Rich](https://rich.readthedocs.io/en/latest/progress.html) when processing input files

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/1324225/152694684-1628731a-b54f-4b67-a7d5-1b0cab2d6ed8.png">
