### PR TITLE
Fix local variable 'activities' referenced before assignment

### DIFF
--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -45,6 +45,7 @@ def main():
     print("Processing data...")
     df = process_data(args.path)
 
+    activities = None
     if args.activities_path:
         print("Processing activities...")
         activities = process_activities(args.activities_path)


### PR DESCRIPTION
Followup to https://github.com/marcusvolz/strava_py/pull/10.

From CI:
```
Traceback (most recent call last):
Plotting landscape...
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 193, in _run_module_as_main
Saved to strava-landscape.png
    "__main__", mod_spec)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts\stravavis.exe\__main__.py", line 7, in <module>
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\stravavis\cli.py", line [72](https://github.com/marcusvolz/strava_py/runs/5136794948?check_suite_focus=true#step:5:72), in main
    if activities:
UnboundLocalError: local variable 'activities' referenced before assignment
Error: Process completed with exit code 1.
```
https://github.com/marcusvolz/strava_py/runs/5136794948?check_suite_focus=true

Need to initialise `activities = None` in case this `if` doesn't run:

```python
    activities = None
    if args.activities_path:
        print("Processing activities...")
        activities = process_activities(args.activities_path)
```

So there's a variable to check here:

```python
    if activities:
        print("Plotting calendar...")
        outfile = f"{args.output_prefix}-calendar.png"
        plot_calendar(activities, output_file=outfile)
        print(f"Saved to {outfile}")
```