### PR TITLE
Fix ValueError with --activities_path

### DIFF
--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -69,8 +69,8 @@ def main():
     outfile = f"{args.output_prefix}-landscape.png"
     plot_landscape(df, output_file=outfile)
     print(f"Saved to {outfile}")
-    
-    if activities:
+
+    if activities is not None:
         print("Plotting calendar...")
         outfile = f"{args.output_prefix}-calendar.png"
         plot_calendar(activities, output_file=outfile)


### PR DESCRIPTION
Oops, I should have actually tested https://github.com/marcusvolz/strava_py/pull/11 with `--activities_path` file:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/bin/stravavis", line 33, in <module>
    sys.exit(load_entry_point('stravavis', 'console_scripts', 'stravavis')())
  File "/Users/hugo/github/strava_py/src/stravavis/cli.py", line 73, in main
    if activities:
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pandas/core/generic.py", line 1537, in __nonzero__
    raise ValueError(
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

So this one should be `is not None`.
