### PR TITLE
Allow `--activities_path` to point to file or directory

### DIFF
--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -32,6 +32,9 @@ def main():
     if os.path.isdir(args.path):
         args.path = os.path.join(args.path, "*")
 
+    if args.activities_path and os.path.isdir(args.activities_path):
+        args.activities_path = os.path.join(args.activities_path, "activities.csv")
+
     # Normally imports go at the top, but scientific libraries can be slow to import
     # so let's validate arguments first
     from stravavis.plot_calendar import plot_calendar


### PR DESCRIPTION
Allow `--activities_path` to specify the path to the actual file: 

```sh
stravavis tests/gpx --activities_path ~/github/strava-tools/activities.csv
```

Or the directory containing the file:

```sh
stravavis tests/gpx --activities_path ~/github/strava-tools/
```
