### PR TITLE
Add --bbox CLI param as a shortcut

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -36,7 +36,7 @@ jobs:
           stravavis tests/gpx
 
       - name: Upload output images
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: images
           path: "*.png"

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -12,10 +12,26 @@ def main():
     parser.add_argument(
         "-o", "--output_prefix", default="strava", help="Prefix for output PNG files"
     )
-    parser.add_argument("--lon_min", default=None, help="Minimum longitude for plot_map (values less than this are removed from the data)")
-    parser.add_argument("--lon_max", default=None, help="Maximum longitude for plot_map (values greater than this are removed from the data)")
-    parser.add_argument("--lat_min", default=None, help="Minimum latitude for plot_map (values less than this are removed from the data)")
-    parser.add_argument("--lat_max", default=None, help="Maximum latitude for plot_map (values greater than this are removed from the data)")
+    parser.add_argument(
+        "--lon_min",
+        type=float,
+        help="Minimum longitude for plot_map (values less than this are removed from the data)",
+    )
+    parser.add_argument(
+        "--lon_max",
+        type=float,
+        help="Maximum longitude for plot_map (values greater than this are removed from the data)",
+    )
+    parser.add_argument(
+        "--lat_min",
+        type=float,
+        help="Minimum latitude for plot_map (values less than this are removed from the data)",
+    )
+    parser.add_argument(
+        "--lat_max",
+        type=float,
+        help="Maximum latitude for plot_map (values greater than this are removed from the data)",
+    )
     parser.add_argument("--alpha", default=0.4, help="Line transparency. 0 = Fully transparent, 1 = No transparency")
     parser.add_argument("--linewidth", default=0.4, help="Line width")
     parser.add_argument("--activities_path", help="Path to activities.csv from Strava bulk export zip")
@@ -62,7 +78,16 @@ def main():
 
     print("Plotting map...")
     outfile = f"{args.output_prefix}-map.png"
-    plot_map(df, output_file=outfile)
+    plot_map(
+        df,
+        args.lon_min,
+        args.lon_max,
+        args.lat_min,
+        args.lat_max,
+        args.alpha,
+        args.linewidth,
+        outfile,
+    )
     print(f"Saved to {outfile}")
 
     print("Plotting elevations...")

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -32,6 +32,9 @@ def main():
         type=float,
         help="Maximum latitude for plot_map (values greater than this are removed from the data)",
     )
+    parser.add_argument(
+        "--bbox", help="Shortcut for comma-separated LON_MIN,LAT_MIN,LON_MAX,LAT_MAX"
+    )
     parser.add_argument("--alpha", default=0.4, help="Line transparency. 0 = Fully transparent, 1 = No transparency")
     parser.add_argument("--linewidth", default=0.4, help="Line width")
     parser.add_argument("--activities_path", help="Path to activities.csv from Strava bulk export zip")
@@ -48,6 +51,12 @@ def main():
 
     if os.path.isdir(args.path):
         args.path = os.path.join(args.path, "*")
+
+    if args.bbox:
+        # Convert comma-separated string into floats
+        args.lon_min, args.lat_min, args.lon_max, args.lat_max = (
+            float(x) for x in args.bbox.split(",")
+        )
 
     if args.activities_path and os.path.isdir(args.activities_path):
         args.activities_path = os.path.join(args.activities_path, "activities.csv")


### PR DESCRIPTION
It's a bit tedious to enter four params and values on the command line when creating a map:

`stravavis activities --lon_min 23.516665 --lat_min 60.000467 --lon_max 26.390877 --lat_max 61.360291`

This PR adds a `--bbox` shortcut for those, that takes a [bounding box](https://wiki.openstreetmap.org/wiki/Bounding_Box) of comma-separated values of lon_min, lat_min, lon_max, lat_max:

`stravavis activities --bbox 23.516665,60.000467,26.390877,61.360291`

It's quite easy to find bounding boxes online, for example: http://bboxfinder.com/#60.000467,23.516665,61.360291,26.390877

---

I also noticed that these lat/lon values are not actually passed from the CLI to the plotting function, and neither are `alpha` or `linewidth`, so let's fix that too :)

---

Finally, bump some GitHub Actions versions for the CI.