### PR TITLE
Fix encoding on Windows

### DIFF
--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -18,7 +18,8 @@ def process_file(fpath):
 # Function for processing an individual GPX file
 # Ref: https://pypi.org/project/gpxpy/
 def process_gpx(gpxfile):
-    activity = gpxpy.parse(open(gpxfile, encoding="utf-8"))
+    with open(gpxfile, encoding="utf-8") as f:
+        activity = gpxpy.parse(f)
 
     lon = []
     lat = []

--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -18,7 +18,7 @@ def process_file(fpath):
 # Function for processing an individual GPX file
 # Ref: https://pypi.org/project/gpxpy/
 def process_gpx(gpxfile):
-    activity = gpxpy.parse(open(gpxfile))
+    activity = gpxpy.parse(open(gpxfile, encoding="utf-8"))
 
     lon = []
     lat = []

--- a/tests/gpx/activity_7448910422.gpx
+++ b/tests/gpx/activity_7448910422.gpx
@@ -11,7 +11,7 @@
     <time>2021-09-02T07:10:04.000Z</time>
   </metadata>
   <trk>
-    <name>West Berkshire Cycling</name>
+    <name>West Berkshire Cycling 🍻</name>
     <type>cycling</type>
     <trkseg>
       <trkpt lat="51.401515267789363861083984375" lon="-1.26182804815471172332763671875">


### PR DESCRIPTION
Fixes https://github.com/marcusvolz/strava_py/issues/19, same thing as https://github.com/tkrajina/gpxpy/issues/178#issuecomment-638835751.

This also adds an emoji to one of the test files, which before the fix fails on the CI on Windows (but not macOS or Linux): https://github.com/hugovk/strava_py/actions/runs/2987678688

After the fix, all pass.

---

Also use a "context manager" to open the file, instead of:

```python
activity = gpxpy.parse(open(gpxfile, encoding="utf-8"))
```

Do this:

```python
    with open(gpxfile, encoding="utf-8") as f:
        activity = gpxpy.parse(f)
```

A context manager takes care of closing file handles in case of errors, and is equivalent to

```python
f = open(gpxfile, encoding="utf-8")
try:
    activity = gpxpy.parse(f)
finally:
    file.close()  # this runs no matter what happens
```

More info: https://towardsdatascience.com/why-you-should-use-context-managers-in-python-4f10fe231206