### PR TITLE
Fix squashed maps

### DIFF
--- a/src/stravavis/plot_map.py
+++ b/src/stravavis/plot_map.py
@@ -1,5 +1,27 @@
+from math import log, pi, tan
+
 import matplotlib.pyplot as plt
 from rich.progress import track
+
+# Dummy units
+MAP_WIDTH = 1
+MAP_HEIGHT = 1
+
+
+def convert_x(lon):
+    # Get x value
+    x = (lon + 180) * (MAP_WIDTH / 360)
+    return x
+
+
+def convert_y(lat):
+    # Convert from degrees to radians
+    lat_rad = lat * pi / 180
+
+    # Get y value
+    mercator_n = log(tan((pi / 4) + (lat_rad / 2)))
+    y = (MAP_HEIGHT / 2) + (MAP_WIDTH * mercator_n / (2 * pi))
+    return y
 
 
 def plot_map(df, lon_min=None, lon_max= None, lat_min=None, lat_max=None,
@@ -28,6 +50,11 @@ def plot_map(df, lon_min=None, lon_max= None, lat_min=None, lat_max=None,
     for activity in track(activities, "Plotting activities"):
         x = df[df['name'] == activity]['lon']
         y = df[df['name'] == activity]['lat']
+
+        # Transform to Mercator projection so maps aren't squashed away from equator
+        x = x.transform(convert_x)
+        y = y.transform(convert_y)
+
         plt.plot(x, y, color='black', alpha=alpha, linewidth=linewidth)
 
     # Update plot aesthetics


### PR DESCRIPTION
This is similar to https://github.com/marcusvolz/strava/issues/5.

Here's the same GPX using `main`:

![strava-map](https://user-images.githubusercontent.com/1324225/188309879-64a0e21e-bf26-4d28-8fd2-3933184d843e.png)

Like https://stackoverflow.com/a/14457180/724176, rather than using latitude and longitude values, this uses a Mercator projection calculation to come up with x and y values instead. 

Dummy, unit map width and height values are used, as we don't know and don't need to know the final size as matplotlib will take care of that.

And with this PR:

![strava-map](https://user-images.githubusercontent.com/1324225/188309859-23e1f567-e3b6-4b3d-80e0-efe59984eb7c.png)

Measuring performance:

With `main`,  on 2,946 GPX files (but commenting out some bits of `cli.py` to only run "Processing data..." and "Plotting map..."), it takes 11m45s on a Mac M1 16GB.

With the PR it takes a comparable 11m43s, which is really good because the transform is done by Pandas so presumably in C.



