### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a port of the [R strava package](https://github.com/marcusvolz/strava) t
 Install via pip:
 
 ```sh
-python3 -m pip install pylast
+python3 -m pip install stravavis
 ```
 
 For development:


### PR DESCRIPTION
I accidentally left the name of another package when I copy/pasted the README installation instructions.