### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -42,7 +41,7 @@ install_requires =
     plotnine
     rich
     seaborn
-python_requires = >=3.7
+python_requires = >=3.8
 package_dir = =src
 zip_safe = True
 


### PR DESCRIPTION
Let's drop support for Python 3.7, it's end-of-life this month:

 * https://devguide.python.org/versions/
 * https://peps.python.org/pep-0537/
