### PR TITLE
Require calmap>=0.0.11 to support Pandas 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "calmap",
+  "calmap>=0.0.11",
   "fit2gpx",
   "gpxpy",
   "matplotlib",
-  "pandas<2", # Pending https://github.com/MarvinT/calmap/pull/14
+  "pandas",
   "plotnine",
   "rich",
   "seaborn",

--- a/src/stravavis/__main__.py
+++ b/src/stravavis/__main__.py
@@ -1,4 +1,4 @@
-from stravavis import cli
+from . import cli
 
 if __name__ == "__main__":
     cli.main()

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -85,14 +85,14 @@ def main():
 
     # Normally imports go at the top, but scientific libraries can be slow to import
     # so let's validate arguments first
-    from stravavis.plot_calendar import plot_calendar
-    from stravavis.plot_dumbbell import plot_dumbbell
-    from stravavis.plot_elevations import plot_elevations
-    from stravavis.plot_facets import plot_facets
-    from stravavis.plot_landscape import plot_landscape
-    from stravavis.plot_map import plot_map
-    from stravavis.process_activities import process_activities
-    from stravavis.process_data import process_data
+    from .plot_calendar import plot_calendar
+    from .plot_dumbbell import plot_dumbbell
+    from .plot_elevations import plot_elevations
+    from .plot_facets import plot_facets
+    from .plot_landscape import plot_landscape
+    from .plot_map import plot_map
+    from .process_activities import process_activities
+    from .process_data import process_data
 
     print("Processing data...")
     df = process_data(args.path)

--- a/src/stravavis/plot_dumbbell.py
+++ b/src/stravavis/plot_dumbbell.py
@@ -43,7 +43,7 @@ def plot_dumbbell(
         activities["duration"][i] = pd.Timedelta(
             activities["Elapsed Time"][i], unit="s"
         )
-    activities["end"] = activities["start"] + activities["duration"]
+    activities["end"] = pd.to_datetime(activities["start"] + activities["duration"])
 
     # Remove activities outside the year_min -> year_max window
     activities["year"] = activities["Activity Date"].dt.year


### PR DESCRIPTION
Follow on from https://github.com/marcusvolz/strava_py/pull/32.

https://pypi.org/project/calmap/0.0.11/ has been released and now supports Pandas 2, so we can remove the `pandas<2` limit.

This also revealed a problem with Pandas 2 in stravavis:

```pytb
❯ stravavis tests/gpx --activities_path tests/csv
...
Plotting dumbbell...
/Users/hugo/github/strava_py/src/stravavis/plot_dumbbell.py:43: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
/Users/hugo/github/strava_py/src/stravavis/plot_dumbbell.py:46: PerformanceWarning: Adding/subtracting object-dtype array to DatetimeArray not vectorized.
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/bin/stravavis", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/hugo/github/strava_py/src/stravavis/cli.py", line 142, in main
    plot_dumbbell(activities, output_file=outfile)
  File "/Users/hugo/github/strava_py/src/stravavis/plot_dumbbell.py", line 60, in plot_dumbbell
    activities["end_time"] = activities["end"].dt.time
                             ^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pandas/core/generic.py", line 5989, in __getattr__
    return object.__getattribute__(self, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pandas/core/accessor.py", line 224, in __get__
    accessor_obj = self._accessor(obj)
                   ^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pandas/core/indexes/accessors.py", line 580, in __new__
    raise AttributeError("Can only use .dt accessor with datetimelike values")
AttributeError: Can only use .dt accessor with datetimelike values. Did you mean: 'at'?
```

It's this line:

```python
activities["end"] = activities["start"] + activities["duration"]
```

Printing those with Pandas 1.5.3:

```python
print(activities["start"])
print(activities["duration"])
print(activities["end"])
```

Gives:

```
0   2023-05-23 12:40:57
1   2023-05-27 01:24:16
2   2023-06-02 11:48:52
3   2023-06-09 01:02:03
4   2023-06-09 01:02:03
5   2023-06-10 10:36:58
6   2023-05-20 01:30:00
7   2023-05-13 12:38:00
Name: start, dtype: datetime64[ns]
0    0 days 01:42:04
1    0 days 08:51:12
2    0 days 03:56:34
3    0 days 01:28:00
4    0 days 01:28:00
5    0 days 03:55:42
6    0 days 04:03:19
7    0 days 04:31:43
Name: duration, dtype: object
0   2023-05-23 14:23:01
1   2023-05-27 10:15:28
2   2023-06-02 15:45:26
3   2023-06-09 02:30:03
4   2023-06-09 02:30:03
5   2023-06-10 14:32:40
6   2023-05-20 05:33:19
7   2023-05-13 17:09:43
Name: end, dtype: datetime64[ns]
```

So: datetime64[ns] + object = datetime64[ns], that's fine.

But with Pandas 2.0.3:

```
0   2023-05-23 12:40:57
1   2023-05-27 01:24:16
2   2023-06-02 11:48:52
3   2023-06-09 01:02:03
4   2023-06-09 01:02:03
5   2023-06-10 10:36:58
6   2023-05-20 01:30:00
7   2023-05-13 12:38:00
Name: start, dtype: datetime64[ns]
0    0 days 01:42:04
1    0 days 08:51:12
2    0 days 03:56:34
3    0 days 01:28:00
4    0 days 01:28:00
5    0 days 03:55:42
6    0 days 04:03:19
7    0 days 04:31:43
Name: duration, dtype: object
0    2023-05-23 14:23:01
1    2023-05-27 10:15:28
2    2023-06-02 15:45:26
3    2023-06-09 02:30:03
4    2023-06-09 02:30:03
5    2023-06-10 14:32:40
6    2023-05-20 05:33:19
7    2023-05-13 17:09:43
Name: end, dtype: object
```

datetime64[ns] + object = object


Instead, let's make sure the end time is a datetime:

```python
activities["end"] = pd.to_datetime(activities["start"] + activities["duration"])
```

This works with both Pandas < 2 and >=2.