### PR TITLE
Deploy to PyPI using Trusted Publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  # Upload to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'marcusvolz'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    if: |
+      github.repository_owner == 'marcusvolz'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Trusted Publishing is a way to use short-lived tokens to automatically upload to PyPI:

https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

It is more secure: the release is made from a clean CI run rather than the maintainer's own computer (we're using this method). Also the tokens are short-lived and don't rely on storing long-lived API tokens on your computer or in the repo.

It's automated, and more reproducible, and makes it easier to release.

This workflow shows a preview of what would be released for every run. For merges to `main`, it deploys to TestPyPI, and when creating a "GitHub release" it deploys to production PyPI.

I've set up both TestPyPI and PyPI for this, it looks like [this](https://pypi.org/manage/project/stravavis/settings/publishing/):

<img width="476" alt="image" src="https://github.com/marcusvolz/strava_py/assets/1324225/2d73d23b-5a29-44ee-98c4-5c8e6c9c77e6">

Here's a preview: 

https://github.com/marcusvolz/strava_py/actions/runs/7370157427?pr=39

I'll update `RELEASING.md` after doing a new release to support 3.12.

