### PR TITLE
Cache processed activities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,5 @@ version.source = "vcs"
 local_scheme = "no-local-version"
 
 [tool.isort]
+add_imports = "from __future__ import annotations"
 profile = "black"

--- a/src/stravavis/__main__.py
+++ b/src/stravavis/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import cli
 
 if __name__ == "__main__":

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import glob
 import os.path

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -89,7 +89,7 @@ def main():
     if os.path.isdir(args.path):
         args.path = os.path.join(args.path, "*")
 
-    filenames = glob.glob(args.path)
+    filenames = sorted(glob.glob(args.path))
     if not filenames:
         sys.exit(f"No files found matching {args.path}")
 

--- a/src/stravavis/plot_calendar.py
+++ b/src/stravavis/plot_calendar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import calmap
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/src/stravavis/plot_dumbbell.py
+++ b/src/stravavis/plot_dumbbell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 from plotnine import (
     aes,

--- a/src/stravavis/plot_elevations.py
+++ b/src/stravavis/plot_elevations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import matplotlib.pyplot as plt

--- a/src/stravavis/plot_facets.py
+++ b/src/stravavis/plot_facets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import matplotlib.pyplot as plt

--- a/src/stravavis/plot_landscape.py
+++ b/src/stravavis/plot_landscape.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import pandas as pd
 from rich.progress import track

--- a/src/stravavis/plot_map.py
+++ b/src/stravavis/plot_map.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from math import log, pi, tan
 
 import matplotlib.pyplot as plt

--- a/src/stravavis/process_activities.py
+++ b/src/stravavis/process_activities.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 
 

--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import glob
 import hashlib
 import math
 import tempfile


### PR DESCRIPTION
This speeds up the "Processing data..." step by caching the generated Pandas dataframe as a pickle file on disk.

For example, with an 8-core Mac, processing all my 3,699 GPX files takes 34s on first pass and creates a 305 MB cache file on disk (the GPX files are 822 MB). For the second run, it takes less than 2s to load the cache file.

For 580 GPX files from 2023, it takes 4s on first pass to create a 50 MB file.

Also add some type hints.