### PR TITLE
Exit with better error if no files found

### DIFF
--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -1,5 +1,7 @@
 import argparse
+import glob
 import os.path
+import sys
 
 
 def main():
@@ -87,6 +89,10 @@ def main():
     if os.path.isdir(args.path):
         args.path = os.path.join(args.path, "*")
 
+    filenames = glob.glob(args.path)
+    if not filenames:
+        sys.exit(f"No files found matching {args.path}")
+
     if args.bbox:
         # Convert comma-separated string into floats
         args.lon_min, args.lat_min, args.lon_max, args.lat_max = (
@@ -108,7 +114,7 @@ def main():
     from .process_data import process_data
 
     print("Processing data...")
-    df = process_data(args.path)
+    df = process_data(filenames)
 
     activities = None
     if args.activities_path:

--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from multiprocessing import Pool
 

--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -1,4 +1,3 @@
-import glob
 import math
 from multiprocessing import Pool
 
@@ -101,10 +100,8 @@ def process_fit(fitfile):
 
 
 # Function for processing (unzipped) GPX and FIT files in a directory (path)
-def process_data(path):
+def process_data(filenames: list[str]) -> pd.DataFrame:
     # Process all files (GPX or FIT)
-    filenames = glob.glob(path)
-
     with Pool() as pool:
         try:
             it = pool.imap_unordered(process_file, filenames)


### PR DESCRIPTION
I accidentally ran this and forgot the `*` to match all filenames beginning with 2023, `activities/2023` instead of `activities/2023*`, and got an ugly error:

```pytb
❯ stravavis --activities_path . "activities/2023"
Processing data...
Processing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/bin/stravavis", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/hugo/github/strava_py/src/stravavis/cli.py", line 111, in main
    df = process_data(args.path)
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/strava_py/src/stravavis/process_data.py", line 117, in process_data
    df = pd.concat(processed)
         ^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pandas/core/reshape/concat.py", line 380, in concat
    op = _Concatenator(
         ^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pandas/core/reshape/concat.py", line 443, in __init__
    objs, keys = self._clean_keys_and_objs(objs, keys)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pandas/core/reshape/concat.py", line 505, in _clean_keys_and_objs
    raise ValueError("No objects to concatenate")
ValueError: No objects to concatenate
```

Let's handle that in a better way:

```console
❯ stravavis --activities_path . "activities/2023"
No files found matching activities/2023
```
