### PR TITLE
Skip segments with empty trkseg

### DIFF
--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -117,6 +117,8 @@ def main():
 
     print("Processing data...")
     df = process_data(filenames)
+    if df.empty:
+        sys.exit("No data to plot")
 
     activities = None
     if args.activities_path:

--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -38,6 +38,9 @@ def process_gpx(gpxfile: str) -> pd.DataFrame | None:
 
     for activity_track in activity.tracks:
         for segment in activity_track.segments:
+            if not activity.tracks[0].segments[0].points:
+                continue
+
             x0 = activity.tracks[0].segments[0].points[0].longitude
             y0 = activity.tracks[0].segments[0].points[0].latitude
             d0 = 0

--- a/src/stravavis/process_data.py
+++ b/src/stravavis/process_data.py
@@ -38,11 +38,11 @@ def process_gpx(gpxfile: str) -> pd.DataFrame | None:
 
     for activity_track in activity.tracks:
         for segment in activity_track.segments:
-            if not activity.tracks[0].segments[0].points:
+            if not segment.points:
                 continue
 
-            x0 = activity.tracks[0].segments[0].points[0].longitude
-            y0 = activity.tracks[0].segments[0].points[0].latitude
+            x0 = segment.points[0].longitude
+            y0 = segment.points[0].latitude
             d0 = 0
             for point in segment.points:
                 x = point.longitude

--- a/tests/gpx/empty-trkseg.gpx
+++ b/tests/gpx/empty-trkseg.gpx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1" creator="https://github.com/georust/gpx">
+  <trk>
+    <trkseg />
+  </trk>
+</gpx>


### PR DESCRIPTION
Fixes https://github.com/marcusvolz/strava_py/issues/45.

---

Looking a bit closer, are we miscalculating the distance?

Simplifying this loop:

```python
    for activity_track in activity.tracks:
        for segment in activity_track.segments:
            x0 = activity.tracks[0].segments[0].points[0].longitude
            y0 = activity.tracks[0].segments[0].points[0].latitude
            d0 = 0
            for point in segment.points:
                x = point.longitude
                y = point.latitude
                d = d0 + math.sqrt(math.pow(x - x0, 2) + math.pow(y - y0, 2))
                dist.append(d)
                x0 = x
                y0 = y
```

If we have two segments, should we be setting the initial (x0, y0) to the first point of _each segment_?

And not always to the first point of the _first segment_?
