### PR TITLE
Add option to choose which visualisations to generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ stravavis activities --bbox 24.782802,59.922486,25.254511,60.29785`
 To only plot certain visualisations:
 
 ```sh
-stravavis activities --vis map facets landscape
+stravavis activities --plot map facets landscape
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ Then run from the terminal:
 stravavis --help
 ```
 
+## How to use
+
+If your activity data is in a folder called `activities`, run the following command:
+
+```sh
+stravavis activities
+```
+
+By default, this will create output images prefixed `strava-`.
+
+If you have an `activities.csv` file:
+
+```sh
+stravavis activities --activities_path activities.csv
+```
+
+To only map activities contained within a
+[bounding box](https://boundingbox.klokantech.com/):
+
+```sh
+stravavis activities --bbox 24.782802,59.922486,25.254511,60.29785`
+```
+
+To only plot certain visualisations:
+
+```sh
+stravavis activities --vis map facets landscape
+```
+
 ## Examples
 
 ### Facets
@@ -69,9 +98,7 @@ Requires "activities.csv" from the bulk Strava export.
 
 ![map](https://raw.githubusercontent.com/marcusvolz/strava_py/main/plots/dumbbell001.png "Dumbbell plot")
 
-## How to use
-
-### Bulk export from Strava
+## Bulk export from Strava
 
 The process for downloading data is described on the Strava website here:
 [https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export#Bulk],
@@ -92,7 +119,10 @@ but in essence, do the following:
 7. Click the link in email to download zipped folder containing activities
 8. Unzip files
 
-### Process the data
+## Programmatic use
+
+The package can also be used programmatically. The following code snippets demonstrate
+how to use the package to create the visualisations.
 
 The main function for importing and processing activity files expects a path to a
 directory of unzipped GPX and / or FIT files. If required, the

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -5,6 +5,16 @@ import glob
 import os.path
 import sys
 
+VISUALISATIONS = {
+    "all",
+    "calendar",
+    "dumbbell",
+    "elevations",
+    "facets",
+    "landscape",
+    "map",
+}
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -12,6 +22,13 @@ def main():
     )
     parser.add_argument(
         "path", help="Input path specification to folder with GPX and / or FIT files"
+    )
+    parser.add_argument(
+        "--vis",
+        default="all",
+        choices=VISUALISATIONS,
+        nargs="+",
+        help="Which visualisations to generate",
     )
     parser.add_argument(
         "-o", "--output_prefix", default="strava", help="Prefix for output PNG files"
@@ -85,6 +102,9 @@ def main():
     )
     args = parser.parse_args()
 
+    if "all" in args.vis:
+        args.vis = VISUALISATIONS
+
     # Expand "~" or "~user"
     args.path = os.path.expanduser(args.path)
 
@@ -106,13 +126,6 @@ def main():
 
     # Normally imports go at the top, but scientific libraries can be slow to import
     # so let's validate arguments first
-    from .plot_calendar import plot_calendar
-    from .plot_dumbbell import plot_dumbbell
-    from .plot_elevations import plot_elevations
-    from .plot_facets import plot_facets
-    from .plot_landscape import plot_landscape
-    from .plot_map import plot_map
-    from .process_activities import process_activities
     from .process_data import process_data
 
     print("Processing data...")
@@ -122,68 +135,88 @@ def main():
 
     activities = None
     if args.activities_path:
+        from .process_activities import process_activities
+
         print("Processing activities...")
         activities = process_activities(args.activities_path)
 
-    print("Plotting facets...")
-    outfile = f"{args.output_prefix}-facets.png"
-    plot_facets(df, output_file=outfile)
-    print(f"Saved to {outfile}")
+    if "facets" in args.vis:
+        from .plot_facets import plot_facets
 
-    print("Plotting map...")
-    outfile = f"{args.output_prefix}-map.png"
-    plot_map(
-        df,
-        args.lon_min,
-        args.lon_max,
-        args.lat_min,
-        args.lat_max,
-        args.alpha,
-        args.linewidth,
-        outfile,
-    )
-    print(f"Saved to {outfile}")
+        print("Plotting facets...")
+        outfile = f"{args.output_prefix}-facets.png"
+        plot_facets(df, output_file=outfile)
+        print(f"Saved to {outfile}")
 
-    print("Plotting elevations...")
-    outfile = f"{args.output_prefix}-elevations.png"
-    plot_elevations(df, output_file=outfile)
-    print(f"Saved to {outfile}")
+    if "map" in args.vis:
+        from .plot_map import plot_map
 
-    print("Plotting landscape...")
-    outfile = f"{args.output_prefix}-landscape.png"
-    plot_landscape(df, output_file=outfile)
-    print(f"Saved to {outfile}")
+        print("Plotting map...")
+        outfile = f"{args.output_prefix}-map.png"
+        plot_map(
+            df,
+            args.lon_min,
+            args.lon_max,
+            args.lat_min,
+            args.lat_max,
+            args.alpha,
+            args.linewidth,
+            outfile,
+        )
+        print(f"Saved to {outfile}")
+
+    if "elevations" in args.vis:
+        from .plot_elevations import plot_elevations
+
+        print("Plotting elevations...")
+        outfile = f"{args.output_prefix}-elevations.png"
+        plot_elevations(df, output_file=outfile)
+        print(f"Saved to {outfile}")
+
+    if "landscape" in args.vis:
+        from .plot_landscape import plot_landscape
+
+        print("Plotting landscape...")
+        outfile = f"{args.output_prefix}-landscape.png"
+        plot_landscape(df, output_file=outfile)
+        print(f"Saved to {outfile}")
 
     if activities is not None:
-        print("Plotting calendar...")
-        outfile = f"{args.output_prefix}-calendar.png"
-        fig_height = args.fig_height or 15
-        fig_width = args.fig_width or 9
-        plot_calendar(
-            activities,
-            args.year_min,
-            args.year_max,
-            args.max_dist,
-            fig_height,
-            fig_width,
-            outfile,
-        )
-        print(f"Saved to {outfile}")
+        if "calendar" in args.vis:
+            from .plot_calendar import plot_calendar
 
-        print("Plotting dumbbell...")
-        outfile = f"{args.output_prefix}-dumbbell.png"
-        fig_height = args.fig_height or 34
-        fig_width = args.fig_width or 34
-        plot_dumbbell(
-            activities,
-            args.year_min,
-            args.year_max,
-            args.local_timezone,
-            fig_height,
-            fig_width,
-            outfile,
-        )
-        print(f"Saved to {outfile}")
+            print("Plotting calendar...")
+            outfile = f"{args.output_prefix}-calendar.png"
+            fig_height = args.fig_height or 15
+            fig_width = args.fig_width or 9
+            plot_calendar(
+                activities,
+                args.year_min,
+                args.year_max,
+                args.max_dist,
+                fig_height,
+                fig_width,
+                outfile,
+            )
+            print(f"Saved to {outfile}")
+
+        if "dumbbell" in args.vis:
+            from .plot_dumbbell import plot_dumbbell
+
+            print("Plotting dumbbell...")
+            outfile = f"{args.output_prefix}-dumbbell.png"
+            fig_height = args.fig_height or 34
+            fig_width = args.fig_width or 34
+            plot_dumbbell(
+                activities,
+                args.year_min,
+                args.year_max,
+                args.local_timezone,
+                fig_height,
+                fig_width,
+                outfile,
+            )
+            print(f"Saved to {outfile}")
 
 
 if __name__ == "__main__":

--- a/src/stravavis/cli.py
+++ b/src/stravavis/cli.py
@@ -24,11 +24,11 @@ def main():
         "path", help="Input path specification to folder with GPX and / or FIT files"
     )
     parser.add_argument(
-        "--vis",
+        "--plot",
         default="all",
         choices=VISUALISATIONS,
         nargs="+",
-        help="Which visualisations to generate",
+        help="Which visualisations to plot",
     )
     parser.add_argument(
         "-o", "--output_prefix", default="strava", help="Prefix for output PNG files"
@@ -102,8 +102,8 @@ def main():
     )
     args = parser.parse_args()
 
-    if "all" in args.vis:
-        args.vis = VISUALISATIONS
+    if "all" in args.plot:
+        args.plot = VISUALISATIONS
 
     # Expand "~" or "~user"
     args.path = os.path.expanduser(args.path)
@@ -140,7 +140,7 @@ def main():
         print("Processing activities...")
         activities = process_activities(args.activities_path)
 
-    if "facets" in args.vis:
+    if "facets" in args.plot:
         from .plot_facets import plot_facets
 
         print("Plotting facets...")
@@ -148,7 +148,7 @@ def main():
         plot_facets(df, output_file=outfile)
         print(f"Saved to {outfile}")
 
-    if "map" in args.vis:
+    if "map" in args.plot:
         from .plot_map import plot_map
 
         print("Plotting map...")
@@ -165,7 +165,7 @@ def main():
         )
         print(f"Saved to {outfile}")
 
-    if "elevations" in args.vis:
+    if "elevations" in args.plot:
         from .plot_elevations import plot_elevations
 
         print("Plotting elevations...")
@@ -173,7 +173,7 @@ def main():
         plot_elevations(df, output_file=outfile)
         print(f"Saved to {outfile}")
 
-    if "landscape" in args.vis:
+    if "landscape" in args.plot:
         from .plot_landscape import plot_landscape
 
         print("Plotting landscape...")
@@ -182,7 +182,7 @@ def main():
         print(f"Saved to {outfile}")
 
     if activities is not None:
-        if "calendar" in args.vis:
+        if "calendar" in args.plot:
             from .plot_calendar import plot_calendar
 
             print("Plotting calendar...")
@@ -200,7 +200,7 @@ def main():
             )
             print(f"Saved to {outfile}")
 
-        if "dumbbell" in args.vis:
+        if "dumbbell" in args.plot:
             from .plot_dumbbell import plot_dumbbell
 
             print("Plotting dumbbell...")


### PR DESCRIPTION
By default, all the visualisations are generated when running the CLI.

Sometimes though, I want to iterate and adjust the parameters to generate a map with a smaller bbox, or for a different time period. So I don't need to regenerate all the other files, which can be slow.

This adds an option `--vis` (open to another name).

By default, it will generate all.

Or you can give `--vis map` to just generate the map, or give multiple like `--vis map facets landscape`.

Also gives some example CLI use right at the top of the README.