### PR TITLE
Ensure pandas>=2 to work with NumPy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "fit2gpx",
   "gpxpy",
   "matplotlib",
-  "pandas",
+  "pandas>=2",
   "plotnine",
   "rich",
   "seaborn",


### PR DESCRIPTION
This will fix the installation errors seen for example at https://github.com/marcusvolz/strava_py/pull/50.

It was because some combination of dependencies meant pandas 1.5.3 was installed which isn't compatible with NumPy 2.

So let's ensure pandas 2+ is installed.