### PR TITLE
Fix timezone comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To only map activities contained within a
 [bounding box](https://boundingbox.klokantech.com/):
 
 ```sh
-stravavis activities --bbox 24.782802,59.922486,25.254511,60.29785`
+stravavis activities --bbox 24.782802,59.922486,25.254511,60.29785
 ```
 
 Or as a shortcut, save bounding-box coordinates to a file:

--- a/src/stravavis/plot_calendar.py
+++ b/src/stravavis/plot_calendar.py
@@ -20,10 +20,14 @@ def plot_calendar(
     plt.figure()
 
     # Process data
-    activities["Activity Date"] = pd.to_datetime(
-        activities["Activity Date"], format=ACTIVITY_FORMAT
+    activities = activities.assign(
+        **{
+            "Activity Date": pd.to_datetime(
+                activities["Activity Date"], format=ACTIVITY_FORMAT
+            )
+        }
     )
-    activities["date"] = activities["Activity Date"].dt.date
+    activities = activities.assign(date=activities["Activity Date"].dt.date)
     activities = activities.groupby(["date"])["Distance"].sum()
     activities.index = pd.to_datetime(activities.index)
     activities.clip(0, max_dist, inplace=True)

--- a/src/stravavis/plot_dumbbell.py
+++ b/src/stravavis/plot_dumbbell.py
@@ -29,7 +29,7 @@ def plot_dumbbell(
 ):
     # Convert activity start date to datetime
     activities = activities.assign(
-        **{"Activity Date": pd.to_datetime(activities["Activity Date"])}
+        **{"Activity Date": pd.to_datetime(activities["Activity Date"], format="mixed")}
     )
 
     # Convert to local timezone (if given)

--- a/src/stravavis/plot_dumbbell.py
+++ b/src/stravavis/plot_dumbbell.py
@@ -28,43 +28,53 @@ def plot_dumbbell(
     output_file="dumbbell.png",
 ):
     # Convert activity start date to datetime
-    activities["Activity Date"] = pd.to_datetime(activities["Activity Date"])
+    activities = activities.assign(
+        **{"Activity Date": pd.to_datetime(activities["Activity Date"])}
+    )
 
     # Convert to local timezone (if given)
     if local_timezone:
-        activities["Activity Date"] = (
-            pd.to_datetime(activities["Activity Date"])
-            .dt.tz_localize(tz="UTC", nonexistent="NaT", ambiguous="NaT")
-            .dt.tz_convert(local_timezone)
+        activities = activities.assign(
+            **{
+                "Activity Date": (
+                    pd.to_datetime(activities["Activity Date"])
+                    .dt.tz_localize(tz="UTC", nonexistent="NaT", ambiguous="NaT")
+                    .dt.tz_convert(local_timezone)
+                )
+            }
         )
 
     # Get activity start and end times
-    activities["start"] = activities["Activity Date"]
-    activities["duration"] = pd.to_timedelta(activities["Elapsed Time"], unit="s")
-    activities["end"] = pd.to_datetime(activities["start"] + activities["duration"])
-
-    # Remove activities outside the year_min -> year_max window
-    activities["year"] = activities["Activity Date"].dt.year
+    activities = activities.assign(
+        start=activities["Activity Date"],
+        duration=pd.to_timedelta(activities["Elapsed Time"], unit="s"),
+    )
+    activities = activities.assign(
+        end=pd.to_datetime(activities["start"] + activities["duration"]),
+        year=activities["Activity Date"].dt.year,
+    )
 
     if year_min:
-        activities = activities[activities["year"] >= year_min]
+        activities = activities[activities["year"] >= year_min].copy()
 
     if year_max:
-        activities = activities[activities["year"] <= year_max]
+        activities = activities[activities["year"] <= year_max].copy()
 
     # Get day of year and time of day data
-    activities["dayofyear"] = activities["Activity Date"].dt.dayofyear
-    activities["start_time"] = activities["start"].dt.time
-    activities["end_time"] = activities["end"].dt.time
-    activities["x"] = (
-        activities["start"].dt.hour
-        + activities["start"].dt.minute / 60
-        + activities["start"].dt.second / 60 / 60
-    )
-    activities["xend"] = (
-        activities["end"].dt.hour
-        + activities["end"].dt.minute / 60
-        + activities["end"].dt.second / 60 / 60
+    activities = activities.assign(
+        dayofyear=activities["Activity Date"].dt.dayofyear,
+        start_time=activities["start"].dt.time,
+        end_time=activities["end"].dt.time,
+        x=(
+            activities["start"].dt.hour
+            + activities["start"].dt.minute / 60
+            + activities["start"].dt.second / 60 / 60
+        ),
+        xend=(
+            activities["end"].dt.hour
+            + activities["end"].dt.minute / 60
+            + activities["end"].dt.second / 60 / 60
+        ),
     )
 
     # Create plotnine / ggplot

--- a/src/stravavis/plot_landscape.py
+++ b/src/stravavis/plot_landscape.py
@@ -10,7 +10,7 @@ def plot_landscape(df, output_file="landscape.png"):
     plt.figure()
 
     # Convert ele to numeric
-    df["ele"] = pd.to_numeric(df["ele"])
+    df = df.assign(ele=pd.to_numeric(df["ele"]))
 
     # Create a list of activity names
     activities = df["name"].unique()


### PR DESCRIPTION
Something is causing newer pandas to fail when comparing timestamps in `df = pd.concat(processed)`:

```pytb
Processing data...
Cache filename: /var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/stravavis/cached_activities_7b5a45ee89db2e5ba5f6072c4145cd66.pkl
Cache not found
Processing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.14/bin/stravavis", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/hugo/github/strava_py/src/stravavis/cli.py", line 141, in main
    df = process_data(filenames)
  File "/Users/hugo/github/strava_py/src/stravavis/process_data.py", line 146, in process_data
    df = pd.concat(processed)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/reshape/concat.py", line 395, in concat
    return op.get_result()
           ~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/reshape/concat.py", line 684, in get_result
    new_data = concatenate_managers(
        mgrs_indexers, self.new_axes, concat_axis=self.bm_axis, copy=self.copy
    )
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/internals/concat.py", line 189, in concatenate_managers
    values = _concatenate_join_units(join_units, copy=copy)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/internals/concat.py", line 461, in _concatenate_join_units
    empty_dtype, empty_dtype_future = _get_empty_dtype(join_units)
                                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/internals/concat.py", line 548, in _get_empty_dtype
    dtype = find_common_type(dtypes)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/dtypes/cast.py", line 1475, in find_common_type
    res = t._get_common_dtype(types)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/dtypes/dtypes.py", line 932, in _get_common_dtype
    if all(isinstance(t, DatetimeTZDtype) and t.tz == self.tz for t in dtypes):
       ^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/pandas/core/dtypes/dtypes.py", line 932, in <genexpr>
    if all(isinstance(t, DatetimeTZDtype) and t.tz == self.tz for t in dtypes):
                                              ^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/gpxpy/gpxfield.py", line 77, in __eq__
    return self.offset == other.offset # type: ignore
                          ^^^^^^^^^^^^
AttributeError: 'datetime.timezone' object has no attribute 'offset'. Did you mean: 'utcoffset'?
```

GPX files parsed by gpxpy have times with gpxpy's custom SimpleTZ class but others use standard `datetime.timezone`, and only `SimpleTZ` has `.offset`. The fix is to normalise to pandas' native timestamp. We were already doing this, but let's do it earlier, before the concat.


---

Also fix and some other warnings:

```
Processing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--/Users/hugo/github/strava_py/src/stravavis/process_data.py:24: FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
A typical example is when you are setting values in a column of a DataFrame, like:

df["col"][row_indexer] = value

Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy

  df["time"] = pd.to_datetime(df["time"], utc=True)
```
