### PR TITLE
Remove duplicate datetime conversion

### DIFF
--- a/src/stravavis/plot_dumbbell.py
+++ b/src/stravavis/plot_dumbbell.py
@@ -37,7 +37,7 @@ def plot_dumbbell(
         activities = activities.assign(
             **{
                 "Activity Date": (
-                    pd.to_datetime(activities["Activity Date"])
+                    activities["Activity Date"]
                     .dt.tz_localize(tz="UTC", nonexistent="NaT", ambiguous="NaT")
                     .dt.tz_convert(local_timezone)
                 )


### PR DESCRIPTION
It was already converted to datetime in:

```python
    # Convert activity start date to datetime
    activities = activities.assign(
        **{"Activity Date": pd.to_datetime(activities["Activity Date"], format="mixed")}
    )
```
